### PR TITLE
fix: lint TypeScript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     ]
   },
   "lint-staged": {
-    "*.{js,json,md}": "prettier --write"
+    "*.{ts,js,json,md}": "prettier --write"
   },
   "engines": {
     "node": ">=v12.22.12"


### PR DESCRIPTION
This PR makes sure lint staged also lints the TypeScript files.